### PR TITLE
revise volumes for logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /mongodb/**
 /nginx/certificates/**
 /rabbitmq/**
+/logs/**
 /.env
 !.gitkeep
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
     image: ghcr.io/kozzzx/moeflow-backend:${MOEFLOW_BACKEND_VERSION}
     restart: always
     volumes:
-      - ./logs/moeflow-backend.txt:/app/logs/log.txt
+      - ./logs/moeflow-backend:/app/logs
     environment:
       CONFIG_PATH: "/app/config.py"
     env_file:
@@ -41,7 +41,7 @@ services:
     image: ghcr.io/kozzzx/moeflow-backend:${MOEFLOW_BACKEND_VERSION}
     restart: always
     volumes:
-      - ./logs/moeflow-celery-default.txt:/app/logs/log.txt
+      - ./logs/moeflow-celery-default:/app/logs
     environment:
       CONFIG_PATH: "/app/config.py"
     env_file:
@@ -54,7 +54,7 @@ services:
     image: ghcr.io/kozzzx/moeflow-backend:${MOEFLOW_BACKEND_VERSION}
     restart: always
     volumes:
-      - ./logs/moeflow-celery-output.txt:/app/logs/log.txt
+      - ./logs/moeflow-celery-output:/app/logs
     environment:
       CONFIG_PATH: "/app/config.py"
     env_file:


### PR DESCRIPTION
如果clone后不手动创建相应log文件 docker-compose会创建一个叫log.txt的 *目录* 导致容器内无法写入log

-------

rationale: when source path does not exist in filesystem, docker-compose creates a dir rather than a file.