### PR TITLE
fix 'environment' map for frontend

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,7 +73,7 @@ services:
       - "80:80"
       - "443:443"
     environment:
-      - DOMAIN: ${DOMAIN}
+      DOMAIN: ${DOMAIN}
     networks:
       - default
 


### PR DESCRIPTION
to mitigate 'services.moeflow-frontend.environment.0 must be a string'